### PR TITLE
Fix POST notification contract schemas for new response fields

### DIFF
--- a/tests/app/public_contracts/schemas/v0/POST_notification_return_email.json
+++ b/tests/app/public_contracts/schemas/v0/POST_notification_return_email.json
@@ -16,7 +16,18 @@
         },
         "body": {"type": "string"},
         "template_version": {"type": "number"},
-        "subject": {"type": "string"}
+        "subject": {"type": "string"},
+        "content": {
+          "type": "object",
+          "properties": {
+            "body": {"type": "string"},
+            "subject": {"type": "string"},
+            "from_email": {"type": ["string", "null"]}
+          },
+          "required": ["body"]
+        },
+        "reference": {"type": ["string", "null"]},
+        "scheduled_for": {"type": ["string", "null"]}
       },
       "additionalProperties": false,
       "required": ["notification", "body", "template_version", "subject"]

--- a/tests/app/public_contracts/schemas/v0/POST_notification_return_sms.json
+++ b/tests/app/public_contracts/schemas/v0/POST_notification_return_sms.json
@@ -15,7 +15,16 @@
           "required": ["id"]
         },
         "body": {"type": "string"},
-        "template_version": {"type": "number"}
+        "template_version": {"type": "number"},
+        "content": {
+          "type": "object",
+          "properties": {
+            "body": {"type": "string"}
+          },
+          "required": ["body"]
+        },
+        "reference": {"type": ["string", "null"]},
+        "scheduled_for": {"type": ["string", "null"]}
       },
       "additionalProperties": false,
       "required": ["notification", "body", "template_version"]


### PR DESCRIPTION
## Summary

- Update JSON Schema contract tests to accept `content`, `reference`, and `scheduled_for` fields in POST notification responses
- These fields were added to `get_notification_return_data()` in the convergence branch but the contract schemas weren't updated

## Test plan

- [x] `tests/app/public_contracts/test_POST_notification.py` — 2 passed
- [x] Full `tests/app/` suite — 1999 passed, 24 failed (all pre-existing), 6 errors (pre-existing)


🤖 Generated with [Claude Code](https://claude.com/claude-code)